### PR TITLE
evaluator: reserve the method.

### DIFF
--- a/evaluator/core/base_evaluator.py
+++ b/evaluator/core/base_evaluator.py
@@ -202,7 +202,10 @@ class BaseEvaluator:
                 sys.modules["handler"] = handler_module
                 spec.loader.exec_module(handler_module)
             
-                if hasattr(handler_module, 'message_handler'):
+                if hasattr(handler_module, 'register_handlers'):
+                    self.message_handler = handler_module.register_handlers(self)
+                    self.logger.info(f"成功设置回调函数: {module_path}.message_handlers")
+                elif hasattr(handler_module, 'message_handler'):
                     self.message_handler = handler_module.message_handler
                     self.logger.info(f"成功设置回调函数: {module_path}.message_handler")
                 else:


### PR DESCRIPTION
* Users can still use the legacy method to do the registration.
* It is a little tricky for current way to do some initialzation for current way. IMO we can revert reserve the origin way.

Suggestions: 
* Maybe we can rename it to `register_handler`(without `s`?). For compatibility reason, I did not add the commit.
